### PR TITLE
Make EmojiconEditText extend AppCompatEditText

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,4 +15,5 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:23.3.0'
+    compile 'com.android.support:appcompat-v7:23.3.0'
 }

--- a/library/src/main/java/com/rockerhieu/emojicon/EmojiconEditText.java
+++ b/library/src/main/java/com/rockerhieu/emojicon/EmojiconEditText.java
@@ -18,14 +18,14 @@ package com.rockerhieu.emojicon;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.v7.widget.AppCompatEditText;
 import android.text.style.DynamicDrawableSpan;
 import android.util.AttributeSet;
-import android.widget.EditText;
 
 /**
  * @author Hieu Rocker (rockerhieu@gmail.com).
  */
-public class EmojiconEditText extends EditText {
+public class EmojiconEditText extends AppCompatEditText {
     private int mEmojiconSize;
     private int mEmojiconAlignment;
     private int mEmojiconTextSize;


### PR DESCRIPTION
This gives EmojiconEditText material look on pre-Lollipop devices.

Before and after:

![emojicon-compat-before](https://cloud.githubusercontent.com/assets/8256809/14808329/75eb099e-0b95-11e6-9323-beadaa2036c4.png) ![emojicon-compat-after](https://cloud.githubusercontent.com/assets/8256809/14808331/77be43f8-0b95-11e6-919e-d9a0a593d242.png)
